### PR TITLE
Greatly Increase Performance

### DIFF
--- a/WindShake/Octree/OctreeRegionUtils.lua
+++ b/WindShake/Octree/OctreeRegionUtils.lua
@@ -2,291 +2,73 @@
 -- @module OctreeRegionUtils
 
 local EPSILON = 1e-6
-local SQRT_3_OVER_2 = math.sqrt(3)/2
+local SQRT_3_OVER_2 = math.sqrt(3) / 2
 local SUB_REGION_POSITION_OFFSET = {
-	{ 0.25, 0.25, -0.25 };
-	{ -0.25, 0.25, -0.25 };
-	{ 0.25, 0.25, 0.25 };
-	{ -0.25, 0.25, 0.25 };
-	{ 0.25, -0.25, -0.25 };
-	{ -0.25, -0.25, -0.25 };
-	{ 0.25, -0.25, 0.25 };
-	{ -0.25, -0.25, 0.25 };
+	{0.25, 0.25, -0.25};
+	{-0.25, 0.25, -0.25};
+	{0.25, 0.25, 0.25};
+	{-0.25, 0.25, 0.25};
+	{0.25, -0.25, -0.25};
+	{-0.25, -0.25, -0.25};
+	{0.25, -0.25, 0.25};
+	{-0.25, -0.25, 0.25};
 }
 
 local OctreeRegionUtils = {}
-
-function OctreeRegionUtils.create(px, py, pz, sx, sy, sz, parent, parentIndex)
-	local hsx, hsy, hsz = sx/2, sy/2, sz/2
-
-	local region = {
-		subRegions = {
-			--topNorthEast
-			--topNorthWest
-			--topSouthEast
-			--topSouthWest
-			--bottomNorthEast
-			--bottomNorthWest
-			--bottomSouthEast
-			--bottomSouthWest
-		};
-		lowerBounds = { px - hsx, py - hsy, pz - hsz };
-		upperBounds = { px + hsx, py + hsy, pz + hsz };
-		position = { px, py, pz };
-		size = { sx, sy, sz }; -- { sx, sy, sz }
-		parent = parent;
-		depth = parent and (parent.depth + 1) or 1;
-		parentIndex = parentIndex;
-		nodes = {}; -- [node] = true (contains subchild nodes too)
-		node_count = 0;
-	}
-
-	-- if region.depth >= 5 then
-	-- 	OctreeRegionUtils.visualize(region)
-	-- end
-
-	return region
-end
-
-function OctreeRegionUtils.addNode(lowestSubregion, node)
-	assert(node)
-
-	local current = lowestSubregion
-	while current do
-		if not current.nodes[node] then
-			current.nodes[node] = node
-			current.node_count = current.node_count + 1
-		end
-		current = current.parent
-	end
-end
-
-function OctreeRegionUtils.moveNode(fromLowest, toLowest, node)
-	assert(fromLowest.depth == toLowest.depth, "fromLowest.depth ~= toLowest.depth")
-	assert(fromLowest ~= toLowest, "fromLowest == toLowest")
-
-	local currentFrom = fromLowest
-	local currentTo = toLowest
-	while currentFrom ~= currentTo do
-		-- remove from current
-		do
-			assert(currentFrom.nodes[node])
-			assert(currentFrom.node_count > 0)
-
-			currentFrom.nodes[node] = nil
-			currentFrom.node_count = currentFrom.node_count - 1
-
-			-- remove subregion!
-			if currentFrom.node_count <= 0 and currentFrom.parentIndex then
-				assert(currentFrom.parent)
-				assert(currentFrom.parent.subRegions[currentFrom.parentIndex] == currentFrom)
-				currentFrom.parent.subRegions[currentFrom.parentIndex] = nil
-			end
-		end
-
-		-- add to new
-		do
-			assert(not currentTo.nodes[node])
-			currentTo.nodes[node] = node
-			currentTo.node_count = currentTo.node_count + 1
-		end
-
-		currentFrom = currentFrom.parent
-		currentTo = currentTo.parent
-	end
-end
-
-function OctreeRegionUtils.removeNode(lowestSubregion, node)
-	assert(node)
-
-	local current = lowestSubregion
-	while current do
-		assert(current.nodes[node])
-		assert(current.node_count > 0)
-
-		current.nodes[node] = nil
-		current.node_count = current.node_count - 1
-
-		-- remove subregion!
-		if current.node_count <= 0 and current.parentIndex then
-			assert(current.parent)
-			assert(current.parent.subRegions[current.parentIndex] == current)
-			current.parent.subRegions[current.parentIndex] = nil
-		end
-
-		current = current.parent
-	end
-end
-
-function OctreeRegionUtils.getSearchRadiusSquared(radius, diameter, epsilon)
-	local diagonal = SQRT_3_OVER_2*diameter
-	local searchRadius = radius + diagonal
-	return searchRadius*searchRadius + epsilon
-end
 
 -- See basic algorithm:
 -- luacheck: push ignore
 -- https://github.com/PointCloudLibrary/pcl/blob/29f192af57a3e7bdde6ff490669b211d8148378f/octree/include/pcl/octree/impl/octree_search.hpp#L309
 -- luacheck: pop
-function OctreeRegionUtils.getNeighborsWithinRadius(
-	region, radius, px, py, pz, objectsFound, nodeDistances2, maxDepth)
-	assert(maxDepth)
+local function GetNeighborsWithinRadius(Region, Radius, PositionX, PositionY, PositionZ, ObjectsFound, NodeDistances2, MaxDepth, ObjectsLength, DistancesLength)
+	if not MaxDepth then
+		error("Missing MaxDepth.")
+	end
 
-	local childDiameter = region.size[1]/2
-	local searchRadiusSquared = OctreeRegionUtils.getSearchRadiusSquared(radius, childDiameter, EPSILON)
-
-	local radiusSquared = radius*radius
+	local SearchRadius = Radius + SQRT_3_OVER_2 * (Region.Size[1] / 2)
+	local SearchRadiusSquared = SearchRadius * SearchRadius + EPSILON
+	local RadiusSquared = Radius * Radius
 
 	-- for each child
-	for _, childRegion in pairs(region.subRegions) do
-		local cposition = childRegion.position
-		local cpx, cpy, cpz = cposition[1], cposition[2], cposition[3]
+	for _, ChildRegion in next, Region.SubRegions do
+		local ChildPosition = ChildRegion.Position
+		local ChildPositionX = ChildPosition[1]
+		local ChildPositionY = ChildPosition[2]
+		local ChildPositionZ = ChildPosition[3]
 
-		local ox, oy, oz = px - cpx, py - cpy, pz - cpz
-		local dist2 = ox*ox + oy*oy + oz*oz
+		local OffsetX = PositionX - ChildPositionX
+		local OffsetY = PositionY - ChildPositionY
+		local OffsetZ = PositionZ - ChildPositionZ
+		local Distance2 = OffsetX * OffsetX + OffsetY * OffsetY + OffsetZ * OffsetZ
 
 		-- within search radius
-		if dist2 <= searchRadiusSquared then
-			if childRegion.depth == maxDepth then
-				for node, _ in pairs(childRegion.nodes) do
-					local npx, npy, npz = node:GetRawPosition()
-					local nox, noy, noz = px - npx, py - npy, pz - npz
-					local ndist2 = nox*nox + noy*noy + noz*noz
-					if ndist2 <= radiusSquared then
-						objectsFound[#objectsFound + 1] = node:GetObject()
-						nodeDistances2[#nodeDistances2 + 1] = ndist2
+		if Distance2 <= SearchRadiusSquared then
+			if ChildRegion.Depth == MaxDepth then
+				for Node in next, ChildRegion.Nodes do
+					local NodePositionX = Node.PositionX
+					local NodePositionY = Node.PositionY
+					local NodePositionZ = Node.PositionZ
+
+					local NodeOffsetX = NodePositionX - PositionX
+					local NodeOffsetY = NodePositionY - PositionY
+					local NodeOffsetZ = NodePositionZ - PositionZ
+					local NodeDistance2 = NodeOffsetX * NodeOffsetX + NodeOffsetY * NodeOffsetY + NodeOffsetZ * NodeOffsetZ
+
+					if NodeDistance2 <= RadiusSquared then
+						ObjectsLength += 1
+						DistancesLength += 1
+						ObjectsFound[ObjectsLength] = Node.Object
+						NodeDistances2[DistancesLength] = NodeDistance2
 					end
 				end
 			else
-				OctreeRegionUtils.getNeighborsWithinRadius(
-					childRegion, radius, px, py, pz, objectsFound, nodeDistances2, maxDepth)
+				ObjectsLength, DistancesLength = GetNeighborsWithinRadius(ChildRegion, Radius, PositionX, PositionY, PositionZ, ObjectsFound, NodeDistances2, MaxDepth, ObjectsLength, DistancesLength)
 			end
 		end
 	end
+
+	return ObjectsLength, DistancesLength
 end
 
-function OctreeRegionUtils.getOrCreateSubRegionAtDepth(region, px, py, pz, maxDepth)
-	local current = region
-	for _ = region.depth, maxDepth do
-		local index = OctreeRegionUtils.getSubRegionIndex(current, px, py, pz)
-		local _next = current.subRegions[index]
-
-		-- construct
-		if not _next then
-			_next = OctreeRegionUtils.createSubRegion(current, index)
-			current.subRegions[index] = _next
-		end
-
-		-- iterate
-		current = _next
-	end
-	return current
-end
-
-function OctreeRegionUtils.createSubRegion(parentRegion, parentIndex)
-	local size = parentRegion.size
-	local position = parentRegion.position
-	local multiplier = SUB_REGION_POSITION_OFFSET[parentIndex]
-
-	local px = position[1] + multiplier[1]*size[1]
-	local py = position[2] + multiplier[2]*size[2]
-	local pz = position[3] + multiplier[3]*size[3]
-	local sx, sy, sz = size[1]/2, size[2]/2, size[3]/2
-
-	return OctreeRegionUtils.create(px, py, pz, sx, sy, sz, parentRegion, parentIndex)
-end
-
--- Consider regions to be range [px, y)
-function OctreeRegionUtils.inRegionBounds(region, px, py, pz)
-	local lowerBounds = region.lowerBounds
-	local upperBounds = region.upperBounds
-	return (
-		px >= lowerBounds[1] and px <= upperBounds[1] and
-			py >= lowerBounds[2] and py <= upperBounds[2] and
-			pz >= lowerBounds[3] and pz <= upperBounds[3]
-	)
-end
-
-function OctreeRegionUtils.getSubRegionIndex(region, px, py, pz)
-	local index = px > region.position[1] and 1 or 2
-	if py <= region.position[2] then
-		index = index + 4
-	end
-
-	if pz >= region.position[3] then
-		index = index + 2
-	end
-	return index
-end
-
---- This definitely collides
--- https://stackoverflow.com/questions/5928725/hashing-2d-3d-and-nd-vectors
-function OctreeRegionUtils.getTopLevelRegionHash(cx, cy, cz)
-	-- Normally you would modulus this to hash table size, but we want as flat of a structure as possible
-	return cx * 73856093 + cy*19351301 + cz*83492791
-end
-
-function OctreeRegionUtils.getTopLevelRegionCellIndex(maxRegionSize, px, py, pz)
-	return math.floor(px / maxRegionSize[1] + 0.5),
-		math.floor(py / maxRegionSize[2] + 0.5),
-		math.floor(pz / maxRegionSize[3] + 0.5)
-end
-
-function OctreeRegionUtils.getTopLevelRegionPosition(maxRegionSize, cx, cy, cz)
-	return maxRegionSize[1] * cx,
-		maxRegionSize[2] * cy,
-		maxRegionSize[3] * cz
-end
-
-function OctreeRegionUtils.areEqualTopRegions(region, rpx, rpy, rpz)
-	local position = region.position
-	return position[1] == rpx
-		and position[2] == rpy
-		and position[3] == rpz
-end
-
-function OctreeRegionUtils.findRegion(regionHashMap, maxRegionSize, px, py, pz)
-	local cx, cy, cz = OctreeRegionUtils.getTopLevelRegionCellIndex(maxRegionSize, px, py, pz)
-	local hash = OctreeRegionUtils.getTopLevelRegionHash(cx, cy, cz)
-
-	local regionList = regionHashMap[hash]
-	if not regionList then
-		return nil
-	end
-
-	local rpx, rpy, rpz = OctreeRegionUtils.getTopLevelRegionPosition(maxRegionSize, cx, cy, cz)
-	for _, region in pairs(regionList) do
-		if OctreeRegionUtils.areEqualTopRegions(region, rpx, rpy, rpz) then
-			return region
-		end
-	end
-
-	return nil
-end
-
-function OctreeRegionUtils.getOrCreateRegion(regionHashMap, maxRegionSize, px, py, pz)
-	local cx, cy, cz = OctreeRegionUtils.getTopLevelRegionCellIndex(maxRegionSize, px, py, pz)
-	local hash = OctreeRegionUtils.getTopLevelRegionHash(cx, cy, cz)
-
-	local regionList = regionHashMap[hash]
-	if not regionList then
-		regionList = {}
-		regionHashMap[hash] = regionList
-	end
-
-	local rpx, rpy, rpz = OctreeRegionUtils.getTopLevelRegionPosition(maxRegionSize, cx, cy, cz)
-	for _, region in pairs(regionList) do
-		if OctreeRegionUtils.areEqualTopRegions(region, rpx, rpy, rpz) then
-			return region
-		end
-	end
-
-	local region = OctreeRegionUtils.create(
-		rpx, rpy, rpz,
-		maxRegionSize[1], maxRegionSize[2], maxRegionSize[3])
-	table.insert(regionList, region)
-
-	return region
-end
-
+OctreeRegionUtils.GetNeighborsWithinRadius = GetNeighborsWithinRadius
 return OctreeRegionUtils

--- a/WindShake/Octree/init.lua
+++ b/WindShake/Octree/init.lua
@@ -90,10 +90,10 @@ function Octree:RadiusSearch(Position: Vector3, Radius: number)
 
 	for _, RegionList in next, self.RegionHashMap do
 		for _, Region in ipairs(RegionList) do
-			local Position = Region.Position
-			local RegionPositionX = Position[1]
-			local RegionPositionY = Position[2]
-			local RegionPositionZ = Position[3]
+			local RegionPosition = Region.Position
+			local RegionPositionX = RegionPosition[1]
+			local RegionPositionY = RegionPosition[2]
+			local RegionPositionZ = RegionPosition[3]
 
 			local OffsetX, OffsetY, OffsetZ = PositionX - RegionPositionX, PositionY - RegionPositionY, PositionZ - RegionPositionZ
 			local Distance2 = OffsetX * OffsetX + OffsetY * OffsetY + OffsetZ * OffsetZ
@@ -132,10 +132,10 @@ function Octree:KNearestNeighborsSearch(Position: Vector3, K: number, Radius: nu
 
 	for _, RegionList in next, self.RegionHashMap do
 		for _, Region in ipairs(RegionList) do
-			local Position = Region.Position
-			local RegionPositionX = Position[1]
-			local RegionPositionY = Position[2]
-			local RegionPositionZ = Position[3]
+			local RegionPosition = Region.Position
+			local RegionPositionX = RegionPosition[1]
+			local RegionPositionY = RegionPosition[2]
+			local RegionPositionZ = RegionPosition[3]
 
 			local OffsetX, OffsetY, OffsetZ = PositionX - RegionPositionX, PositionY - RegionPositionY, PositionZ - RegionPositionZ
 			local Distance2 = OffsetX * OffsetX + OffsetY * OffsetY + OffsetZ * OffsetZ
@@ -218,13 +218,13 @@ function Octree:GetOrCreateLowestSubRegion(PositionX: number, PositionY: number,
 	local MaxDepth = self.MaxDepth
 	local Current = Region
 	for _ = Region.Depth, MaxDepth do
-		local Position = Current.Position
-		local Index = PositionX > Position[1] and 1 or 2
-		if PositionY <= Position[2] then
+		local CurrentPosition = Current.Position
+		local Index = PositionX > CurrentPosition[1] and 1 or 2
+		if PositionY <= CurrentPosition[2] then
 			Index += 4
 		end
 
-		if PositionZ >= Position[3] then
+		if PositionZ >= CurrentPosition[3] then
 			Index += 2
 		end
 
@@ -234,7 +234,6 @@ function Octree:GetOrCreateLowestSubRegion(PositionX: number, PositionY: number,
 		-- construct
 		if not Next then
 			local Size = Current.Size
-			local CurrentPosition = Current.Position
 			local Multiplier = SUB_REGION_POSITION_OFFSET[Index]
 
 			local X, Y, Z = Size[1], Size[2], Size[3]

--- a/WindShake/Settings.lua
+++ b/WindShake/Settings.lua
@@ -1,31 +1,42 @@
 local Settings = {}
 
+local SettingTypes = {
+	WindPower = "number";
+	WindSpeed = "number";
+	WindDirection = "Vector3";
+}
+
 function Settings.new(object, base)
-	local inst = {
-		_object = object;
-		_base = base;
-	}
-	
-	return setmetatable(inst, Settings)
-end
+	local inst = table.create(3)
 
-function Settings:__index(key)
-	local result = self._object:GetAttribute(key)
-	local base = self._base
-	
-	if base ~= nil then
-		base = base[key]
+	-- Initial settings
 
-		if typeof(result) ~= typeof(base) then
-			result = base
-		end
-	end
-	
-	return result
-end
+	local WindPower = object:GetAttribute("WindPower")
+	local WindSpeed = object:GetAttribute("WindSpeed")
+	local WindDirection = object:GetAttribute("WindDirection")
 
-function Settings:__newindex(key, value)
-	self._object:SetAttribute(key, value)
+	inst.WindPower = typeof(WindPower) == SettingTypes.WindPower and WindPower or base.WindPower
+	inst.WindSpeed = typeof(WindSpeed) == SettingTypes.WindSpeed and WindSpeed or base.WindSpeed
+	inst.WindDirection = typeof(WindDirection) == SettingTypes.WindDirection and WindDirection or base.WindDirection
+
+	-- Update settings on event
+
+	object:GetAttributeChangedSignal("WindPower"):Connect(function()
+		WindPower = object:GetAttribute("WindPower")
+		inst.WindPower = typeof(WindPower) == SettingTypes.WindPower and WindPower or base.WindPower
+	end)
+
+	object:GetAttributeChangedSignal("WindSpeed"):Connect(function()
+		WindSpeed = object:GetAttribute("WindSpeed")
+		inst.WindSpeed = typeof(WindSpeed) == SettingTypes.WindSpeed and WindSpeed or base.WindSpeed
+	end)
+
+	object:GetAttributeChangedSignal("WindDirection"):Connect(function()
+		WindDirection = object:GetAttribute("WindDirection")
+		inst.WindDirection = typeof(WindDirection) == SettingTypes.WindDirection and WindDirection or base.WindDirection
+	end)
+
+	return inst
 end
 
 return Settings

--- a/WindShake/Settings.lua
+++ b/WindShake/Settings.lua
@@ -21,20 +21,29 @@ function Settings.new(object, base)
 
 	-- Update settings on event
 
-	object:GetAttributeChangedSignal("WindPower"):Connect(function()
+	local PowerConnection = object:GetAttributeChangedSignal("WindPower"):Connect(function()
 		WindPower = object:GetAttribute("WindPower")
 		inst.WindPower = typeof(WindPower) == SettingTypes.WindPower and WindPower or base.WindPower
 	end)
 
-	object:GetAttributeChangedSignal("WindSpeed"):Connect(function()
+	local SpeedConnection = object:GetAttributeChangedSignal("WindSpeed"):Connect(function()
 		WindSpeed = object:GetAttribute("WindSpeed")
 		inst.WindSpeed = typeof(WindSpeed) == SettingTypes.WindSpeed and WindSpeed or base.WindSpeed
 	end)
 
-	object:GetAttributeChangedSignal("WindDirection"):Connect(function()
+	local DirectionConnection = object:GetAttributeChangedSignal("WindDirection"):Connect(function()
 		WindDirection = object:GetAttribute("WindDirection")
 		inst.WindDirection = typeof(WindDirection) == SettingTypes.WindDirection and WindDirection or base.WindDirection
 	end)
+
+	-- Cleanup function for when shake is removed or object is unloaded
+
+	function inst:Destroy()
+		PowerConnection:Disconnect()
+		SpeedConnection:Disconnect()
+		DirectionConnection:Disconnect()
+		table.clear(inst)
+	end
 
 	return inst
 end

--- a/WindShake/init.lua
+++ b/WindShake/init.lua
@@ -121,12 +121,15 @@ function WindShake:Update(dt)
 	local camera = workspace.CurrentCamera
 	local cameraCF = camera and camera.CFrame
 
+	debug.profilebegin("Octree Search")
 	local updateObjects = self.Octree:RadiusSearch(cameraCF.Position + (cameraCF.LookVector * 115), 120)
+	debug.profileend()
+
 	local activeCount = #updateObjects
 
 	self.Active = activeCount
 
-	if self.Active < 1 then
+	if activeCount < 1 then
 		return
 	end
 
@@ -134,6 +137,7 @@ function WindShake:Update(dt)
 	local cfTable = table.create(activeCount)
 	local objectMetadata = self.ObjectMetadata
 
+	debug.profilebegin("Calc")
 	for i, object in ipairs(updateObjects) do
 		local objMeta = objectMetadata[object]
 		local lastComp = objMeta.LastCompute or 0
@@ -163,6 +167,7 @@ function WindShake:Update(dt)
 		objMeta.CFrame = current
 		cfTable[i] = current
 	end
+	debug.profileend()
 
 	workspace:BulkMoveTo(updateObjects, cfTable, Enum.BulkMoveMode.FireCFrameChanged)
 	debug.profileend()

--- a/WindShake/init.lua
+++ b/WindShake/init.lua
@@ -149,7 +149,7 @@ function WindShake:Update(dt)
 			local objSettings = objMeta.Settings
 
 			local seed = objMeta.Seed
-			local amp = math.abs(objSettings.WindPower * 0.1)
+			local amp = objSettings.WindPower * 0.1
 
 			local freq = now * (objSettings.WindSpeed * 0.08)
 			local rotX = math.noise(freq, 0, seed) * amp
@@ -221,7 +221,7 @@ function WindShake:Init()
 	if typeof(direction) ~= "Vector3" then
 		script:SetAttribute("WindDirection", DEFAULT_SETTINGS.WindDirection)
 	end
-	
+
 	-- Clear any old stuff.
 	self:Cleanup()
 
@@ -274,10 +274,8 @@ function WindShake:UpdateObjectSettings(object: Instance, settingsTable: WindSha
 		return
 	end
 
-	if not self.ObjectMetadata[object] then
-		if object ~= script then
-			return
-		end
+	if (not self.ObjectMetadata[object]) and (object ~= script) then
+		return
 	end
 
 	for key, value in pairs(settingsTable) do
@@ -293,10 +291,8 @@ function WindShake:UpdateAllObjectSettings(settingsTable: WindShakeSettings)
 	end
 
 	for obj, objMeta in pairs(self.ObjectMetadata) do
-		local objSettings = objMeta.Settings
-
 		for key, value in pairs(settingsTable) do
-			objSettings[key] = value
+			obj:SetAttribute(key, value)
 		end
 		ObjectShakeUpdatedEvent:Fire(obj)
 	end

--- a/WindShake/init.lua
+++ b/WindShake/init.lua
@@ -104,6 +104,7 @@ function WindShake:RemoveObjectShake(object: BasePart)
 	if objMeta then
 		self.Handled -= 1
 		metadata[object] = nil
+		objMeta.Settings:Destroy()
 		objMeta.Node:Destroy()
 
 		if object:IsA("BasePart") then

--- a/WindShake/init.lua
+++ b/WindShake/init.lua
@@ -13,7 +13,8 @@ local Settings = require(script.Settings)
 local Octree = require(script.Octree)
 
 local COLLECTION_TAG = "WindShake" -- The CollectionService tag to be watched and mounted automatically
-local UPDATE_HZ = 1/30 -- Update the object targets at 30 Hz.
+local UPDATE_HZ = 1/45 -- Update the object positions at 45 Hz.
+local COMPUTE_HZ = 1/30 -- Compute the object targets at 30 Hz.
 
 -- Use the script's attributes as the default settings.
 -- The table provided is a fallback if the attributes
@@ -39,6 +40,7 @@ local WindShake = {
 
 	Handled = 0;
 	Active = 0;
+	LastUpdate = os.clock();
 
 	ObjectShakeAdded = ObjectShakeAddedEvent.Event;
 	ObjectShakeRemoved = ObjectShakeRemovedEvent.Event;
@@ -115,8 +117,16 @@ function WindShake:RemoveObjectShake(object: BasePart)
 	ObjectShakeRemovedEvent:Fire(object)
 end
 
-function WindShake:Update(dt)
+function WindShake:Update()
 	local now = os.clock()
+	local dt = now - self.LastUpdate
+
+	if dt < UPDATE_HZ then
+		return
+	end
+
+	self.LastUpdate = now
+
 	debug.profilebegin("WindShake")
 
 	local camera = workspace.CurrentCamera
@@ -146,7 +156,7 @@ function WindShake:Update(dt)
 		local origin = objMeta.Origin
 		local current = objMeta.CFrame or origin
 
-		if (now - lastComp) > UPDATE_HZ then
+		if (now - lastComp) > COMPUTE_HZ then
 			local objSettings = objMeta.Settings
 
 			local seed = objMeta.Seed


### PR DESCRIPTION
This module was initially extremely performant, handling tens of thousands of objects at 400+ FPS. However, as more features were added over time, performance took a noticeable hit. There are some users who currently use older versions of WindShake due to performance implications.

This PR will close #4 as it brings the module's performance (in a worst case environment) from 130 FPS to 230 FPS on my machine.

![image](https://user-images.githubusercontent.com/40185666/117701550-3c42bd80-b17c-11eb-90d3-ba412e531b28.png)

This chart demonstrates the improvements to calculation speed from these changes, and this change also decreases how often calculations are made in general.

Issue #4 documents the changes and improvements made in more detail.