### PR TITLE
Support bones

### DIFF
--- a/src/Settings.lua
+++ b/src/Settings.lua
@@ -7,7 +7,7 @@ local SettingTypes = {
 	PivotOffset = "CFrame",
 }
 
-function Settings.new(object: Instance, base)
+function Settings.new(object: BasePart | Bone, base)
 	local inst = {}
 
 	-- Initial settings

--- a/src/VectorMap.lua
+++ b/src/VectorMap.lua
@@ -42,7 +42,7 @@ function VectorMap:AddObject(position: Vector3, object: any)
 
 	if voxel == nil then
 		self._voxels[voxelKey] = {
-			[className] = { object }
+			[className] = { object },
 		}
 	elseif voxel[className] == nil then
 		voxel[className] = { object }

--- a/src/init.lua
+++ b/src/init.lua
@@ -85,7 +85,7 @@ function WindShake:AddObjectShake(object: BasePart | Bone, settingsTable: WindSh
 	end
 
 	metadata[object] = {
-		ChunkKey = self.VectorMap:AddObject(object.Position, object),
+		ChunkKey = self.VectorMap:AddObject(if object:IsA("Bone") then object.WorldPosition else object.Position, object),
 		Settings = Settings.new(object, DEFAULT_SETTINGS),
 
 		Seed = math.random(5000) * 0.32,

--- a/src/init.lua
+++ b/src/init.lua
@@ -181,7 +181,6 @@ function WindShake:Update(deltaTime: number)
 
 		local windDirection = objSettings.WindDirection.Unit
 		local localWindDirection = origin:VectorToObjectSpace(windDirection)
-		local translationalOffset = windDirection * animValue
 
 		if isBone then
 			(object :: Bone).Transform = (
@@ -194,7 +193,7 @@ function WindShake:Update(deltaTime: number)
 					math.noise(seed, freq, 0) * lowAmp,
 					math.noise(freq, seed, 0) * lowAmp
 				)
-			) + translationalOffset
+			) + (localWindDirection * animValue)
 		else
 			local goalCFrame = (
 				origin
@@ -208,7 +207,7 @@ function WindShake:Update(deltaTime: number)
 					math.noise(freq, seed, 0) * lowAmp
 				)
 				* objSettings.PivotOffsetInverse
-			) + translationalOffset
+			) + (windDirection * animValue)
 
 			local lerpedCFrame = objectCFrame:Lerp(
 				goalCFrame,

--- a/src/init.lua
+++ b/src/init.lua
@@ -195,7 +195,7 @@ function WindShake:Update(deltaTime: number)
 						math.noise(seed, freq, 0) * lowAmp,
 						math.noise(freq, seed, 0) * lowAmp
 					)
-				) + (localWindDirection * animValue),
+				) + (localWindDirection * animValue * amp),
 				lerpAlpha
 			)
 		else
@@ -211,7 +211,7 @@ function WindShake:Update(deltaTime: number)
 						math.noise(freq, seed, 0) * lowAmp
 					)
 					* objSettings.PivotOffsetInverse
-				) + (windDirection * animValue),
+				) + (windDirection * animValue * (amp * 2)),
 				lerpAlpha
 			)
 		end

--- a/src/init.lua
+++ b/src/init.lua
@@ -114,8 +114,8 @@ function WindShake:RemoveObjectShake(object: BasePart | Bone)
 		objMeta.Settings:Destroy()
 		self.VectorMap:RemoveObject(objMeta.ChunkKey, object)
 
-		if object:IsA("BasePart") then
-			object.CFrame = objMeta.Origin
+		if object:IsA("BasePart") or object:IsA("Bone") then
+			(object :: any).CFrame = objMeta.Origin
 		end
 	end
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -167,6 +167,8 @@ function WindShake:Update(deltaTime: number)
 		objMeta.LastUpdate = now
 		active += 1
 
+		local isBone = className == "Bone"
+
 		local objSettings = objMeta.Settings
 		local seed = objMeta.Seed
 		local amp = objSettings.WindPower * 0.1
@@ -180,12 +182,12 @@ function WindShake:Update(deltaTime: number)
 						math.noise(freq, 0, -seed) * amp,
 						math.noise(freq, 0, seed + seed) * amp
 					)
-				+ objSettings.WindDirection * ((0.5 + math.noise(freq, seed, seed)) * amp)
+				+ objSettings.WindDirection * ((0.5 + math.noise(freq, seed, seed)) * (amp * if isBone then 0.5 else 1))
 			) * objSettings.PivotOffsetInverse,
 			math.clamp(step + distanceAlphaSq, 0.1, 0.9)
 		)
 
-		if className == "Bone" then
+		if isBone then
 			(object :: Bone).CFrame = goalCFrame
 		else
 			i += 1


### PR DESCRIPTION
Adds support for skinned mesh animation. Closes #14.

https://github.com/boatbomber/WindShake/assets/40185666/75c1ee0a-c762-4267-9e44-7d3785500df2

Creates buckets per voxel for each class, allowing us to handle bones and baseparts differently without needing to run :IsA thousands of times per frame.
