### PR TITLE
Workspace wind setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,20 @@ number WindShake.MaxRefreshRate
 ## Functions
 
 ```Lua
-function WindShake:Init()
+function WindShake:Init(config: {
+    MatchWorkspaceWind: boolean?,
+}?)
 ```
 *Initializes the wind shake logic and adds shake to all tagged objects*
+
+**Parameters:**
+- `config` *[Optional Dictionary]*
+
+    Configuration for the initialization
+    - `MatchWorkspaceWind` *[Optional Boolean]*
+
+        Whether to match the wind settings to the Workspace's GlobalWind setting. Default false
+
 
 **Returns:**
 * `void`
@@ -147,6 +158,16 @@ function WindShake:UpdateAllObjectSettings(Settings)
 
 - `Settings` *[Dictionary]*
 The settings to apply to all objects' shake (See below for Settings structure)
+
+**Returns:**
+* `void`
+
+```Lua
+function WindShake:MatchWorkspaceWind()
+```
+*Sets the wind settings to match the current workspace GlobalWind*
+
+> When `:Init()` is called with the `MatchWorkspaceWind` config set to true, this is called automatically
 
 **Returns:**
 * `void`

--- a/demo/client/WindController/init.client.lua
+++ b/demo/client/WindController/init.client.lua
@@ -18,7 +18,9 @@ WindShake:SetDefaultSettings({
 	WindDirection = WIND_DIRECTION,
 	WindPower = WIND_POWER,
 })
-WindShake:Init()
+WindShake:Init({
+	MatchWorkspaceWind = true,
+})
 
 -- Demo dynamic settings
 

--- a/src/Settings.lua
+++ b/src/Settings.lua
@@ -7,53 +7,54 @@ local SettingTypes = {
 	PivotOffset = "CFrame",
 }
 
-function Settings.new(object: BasePart | Bone, base)
-	local inst = {}
+function Settings.new(object: BasePart | Bone | ModuleScript)
+	local objectSettings = {}
 
 	-- Initial settings
-
 	local WindPower = object:GetAttribute("WindPower")
 	local WindSpeed = object:GetAttribute("WindSpeed")
 	local WindDirection = object:GetAttribute("WindDirection")
 
-	inst.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else base.WindPower
-	inst.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else base.WindSpeed
-	inst.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
+	objectSettings.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else nil
+	objectSettings.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else nil
+	objectSettings.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
 		then WindDirection.Unit
-		else base.WindDirection
-	inst.PivotOffset = if object:IsA("BasePart") then object.PivotOffset else (base.PivotOffset or CFrame.new())
-	inst.PivotOffsetInverse = inst.PivotOffset:Inverse()
+		else nil
+	objectSettings.PivotOffset = if object:IsA("BasePart") then object.PivotOffset else nil
+	objectSettings.PivotOffsetInverse = if typeof(objectSettings.PivotOffset) == "CFrame"
+		then objectSettings.PivotOffset:Inverse()
+		else nil
 
 	-- Update settings on event
 
 	local PowerConnection = object:GetAttributeChangedSignal("WindPower"):Connect(function()
 		WindPower = object:GetAttribute("WindPower")
-		inst.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else base.WindPower
+		objectSettings.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else nil
 	end)
 
 	local SpeedConnection = object:GetAttributeChangedSignal("WindSpeed"):Connect(function()
 		WindSpeed = object:GetAttribute("WindSpeed")
-		inst.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else base.WindSpeed
+		objectSettings.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else nil
 	end)
 
 	local DirectionConnection = object:GetAttributeChangedSignal("WindDirection"):Connect(function()
 		WindDirection = object:GetAttribute("WindDirection")
-		inst.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
+		objectSettings.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
 			then WindDirection.Unit
-			else base.WindDirection
+			else nil
 	end)
 
 	local PivotConnection
 	if object:IsA("BasePart") then
 		PivotConnection = object:GetPropertyChangedSignal("PivotOffset"):Connect(function()
-			inst.PivotOffset = object.PivotOffset
-			inst.PivotOffsetInverse = inst.PivotOffset:Inverse()
+			objectSettings.PivotOffset = object.PivotOffset
+			objectSettings.PivotOffsetInverse = objectSettings.PivotOffset:Inverse()
 		end)
 	end
 
 	-- Cleanup function for when shake is removed or object is unloaded
 
-	function inst:Destroy()
+	function objectSettings:Destroy()
 		PowerConnection:Disconnect()
 		SpeedConnection:Disconnect()
 		DirectionConnection:Disconnect()
@@ -61,10 +62,10 @@ function Settings.new(object: BasePart | Bone, base)
 			PivotConnection:Disconnect()
 		end
 
-		table.clear(inst)
+		table.clear(objectSettings)
 	end
 
-	return inst
+	return objectSettings
 end
 
 return Settings

--- a/src/Settings.lua
+++ b/src/Settings.lua
@@ -16,9 +16,11 @@ function Settings.new(object: BasePart | Bone, base)
 	local WindSpeed = object:GetAttribute("WindSpeed")
 	local WindDirection = object:GetAttribute("WindDirection")
 
-	inst.WindPower = typeof(WindPower) == SettingTypes.WindPower and WindPower or base.WindPower
-	inst.WindSpeed = typeof(WindSpeed) == SettingTypes.WindSpeed and WindSpeed or base.WindSpeed
-	inst.WindDirection = typeof(WindDirection) == SettingTypes.WindDirection and WindDirection or base.WindDirection
+	inst.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else base.WindPower
+	inst.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else base.WindSpeed
+	inst.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
+		then WindDirection.Unit
+		else base.WindDirection
 	inst.PivotOffset = if object:IsA("BasePart") then object.PivotOffset else (base.PivotOffset or CFrame.new())
 	inst.PivotOffsetInverse = inst.PivotOffset:Inverse()
 
@@ -26,17 +28,19 @@ function Settings.new(object: BasePart | Bone, base)
 
 	local PowerConnection = object:GetAttributeChangedSignal("WindPower"):Connect(function()
 		WindPower = object:GetAttribute("WindPower")
-		inst.WindPower = typeof(WindPower) == SettingTypes.WindPower and WindPower or base.WindPower
+		inst.WindPower = if typeof(WindPower) == SettingTypes.WindPower then WindPower else base.WindPower
 	end)
 
 	local SpeedConnection = object:GetAttributeChangedSignal("WindSpeed"):Connect(function()
 		WindSpeed = object:GetAttribute("WindSpeed")
-		inst.WindSpeed = typeof(WindSpeed) == SettingTypes.WindSpeed and WindSpeed or base.WindSpeed
+		inst.WindSpeed = if typeof(WindSpeed) == SettingTypes.WindSpeed then WindSpeed else base.WindSpeed
 	end)
 
 	local DirectionConnection = object:GetAttributeChangedSignal("WindDirection"):Connect(function()
 		WindDirection = object:GetAttribute("WindDirection")
-		inst.WindDirection = typeof(WindDirection) == SettingTypes.WindDirection and WindDirection or base.WindDirection
+		inst.WindDirection = if typeof(WindDirection) == SettingTypes.WindDirection
+			then WindDirection.Unit
+			else base.WindDirection
 	end)
 
 	local PivotConnection

--- a/src/init.lua
+++ b/src/init.lua
@@ -18,11 +18,11 @@ local COLLECTION_TAG = "WindShake" -- The CollectionService tag to be watched an
 -- The table provided is a fallback if the attributes
 -- are undefined or using the wrong value types.
 
-local DEFAULT_SETTINGS = Settings.new(script, {
+local FALLBACK_SETTINGS = {
 	WindDirection = Vector3.new(0.5, 0, 0.5),
 	WindSpeed = 20,
 	WindPower = 0.5,
-})
+}
 
 -----------------------------------------------------------------------------------------------------------------
 
@@ -35,6 +35,7 @@ local ResumedEvent = Instance.new("BindableEvent")
 local WindShake = {
 	RenderDistance = 150,
 	MaxRefreshRate = 1 / 60,
+	SharedSettings = Settings.new(script),
 
 	ObjectMetadata = {},
 	VectorMap = VectorMap.new(),
@@ -89,7 +90,7 @@ function WindShake:AddObjectShake(object: BasePart | Bone, settingsTable: WindSh
 			if object:IsA("Bone") then object.WorldPosition else object.Position,
 			object
 		),
-		Settings = Settings.new(object, DEFAULT_SETTINGS),
+		Settings = Settings.new(object),
 
 		Seed = math.random(5000) * 0.32,
 		Origin = if object:IsA("Bone") then object.WorldCFrame else object.CFrame,
@@ -151,6 +152,10 @@ function WindShake:Update(deltaTime: number)
 	local cameraPos = camera.CFrame.Position
 	local renderDistance = self.RenderDistance
 	local maxRefreshRate = self.MaxRefreshRate
+	local sharedSettings = self.SharedSettings
+	local sharedWindPower = sharedSettings.WindPower
+	local sharedWindSpeed = sharedSettings.WindSpeed
+	local sharedWindDirection = sharedSettings.WindDirection
 
 	-- Update objects in view at their respective refresh rates
 	self.VectorMap:ForEachObjectInView(camera, renderDistance, function(className: string, object: BasePart | Bone)
@@ -174,12 +179,12 @@ function WindShake:Update(deltaTime: number)
 		active += 1
 
 		local objSettings = objMeta.Settings
-		local amp = objSettings.WindPower * 0.2
+		local amp = (objSettings.WindPower or sharedWindPower) * 0.2
 		if amp < 1e-5 then
 			return
 		end
 
-		local freq = now * (objSettings.WindSpeed * 0.08)
+		local freq = now * ((objSettings.WindSpeed or sharedWindSpeed) * 0.08)
 		if freq < 1e-5 then
 			return
 		end
@@ -189,8 +194,8 @@ function WindShake:Update(deltaTime: number)
 		local lerpAlpha = math.clamp(step + distanceAlphaSq, 0.1, 0.5)
 		local lowAmp = amp / 3
 
-		local origin = objMeta.Origin * objSettings.PivotOffset
-		local windDirection = objSettings.WindDirection.Unit
+		local origin = objMeta.Origin * (objSettings.PivotOffset or CFrame.identity)
+		local windDirection = (objSettings.WindDirection or sharedWindDirection)
 		local localWindDirection = origin:VectorToObjectSpace(windDirection)
 
 		if isBone then
@@ -218,7 +223,7 @@ function WindShake:Update(deltaTime: number)
 						math.noise(seed, freq, 0) * lowAmp,
 						math.noise(freq, seed, 0) * lowAmp
 					)
-					* objSettings.PivotOffsetInverse
+					* (objSettings.PivotOffsetInverse or CFrame.identity)
 				) + (windDirection * animValue * (amp * 2)),
 				lerpAlpha
 			)
@@ -270,15 +275,15 @@ function WindShake:Init(config: { MatchWorkspaceWind: boolean? })
 	local direction = script:GetAttribute("WindDirection")
 
 	if typeof(power) ~= "number" then
-		script:SetAttribute("WindPower", DEFAULT_SETTINGS.WindPower)
+		script:SetAttribute("WindPower", FALLBACK_SETTINGS.WindPower)
 	end
 
 	if typeof(speed) ~= "number" then
-		script:SetAttribute("WindSpeed", DEFAULT_SETTINGS.WindSpeed)
+		script:SetAttribute("WindSpeed", FALLBACK_SETTINGS.WindSpeed)
 	end
 
 	if typeof(direction) ~= "Vector3" then
-		script:SetAttribute("WindDirection", DEFAULT_SETTINGS.WindDirection)
+		script:SetAttribute("WindDirection", FALLBACK_SETTINGS.WindDirection)
 	end
 
 	-- Clear any old stuff.
@@ -387,12 +392,6 @@ function WindShake:MatchWorkspaceWind()
 	end
 
 	self:SetDefaultSettings({
-		WindDirection = windDirection,
-		WindSpeed = windSpeed,
-		WindPower = windPower,
-	})
-
-	self:UpdateAllObjectSettings({
 		WindDirection = windDirection,
 		WindSpeed = windSpeed,
 		WindPower = windPower,


### PR DESCRIPTION
Closes #11.

When calling `WindShake:Init()`, the user can pass a config table containing `MatchWorkspaceWind = true`. The initialization will then set up a listener to make sure the winds always match the workspace settings.

For users who want more control over when the wind settings are updated, they can call `WindShake:MatchWorkspaceWind()` themselves.


https://github.com/boatbomber/WindShake/assets/40185666/6f6f8573-81cc-4dba-8dc4-9ffe2680563c

