### PR TITLE
Fixed config type being expected on :Init, despite it not actually being required

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -269,7 +269,7 @@ function WindShake:Resume()
 	ResumedEvent:Fire()
 end
 
-function WindShake:Init(config: { MatchWorkspaceWind: boolean? })
+function WindShake:Init(config: { MatchWorkspaceWind: boolean? }?)
 	if self.Initialized then
 		return
 	end


### PR DESCRIPTION
The WindShake:Init() function expects a config table
```
config: { MatchWorkspaceWind: boolean? }
```
despite it just being optional in the actual implementation.
I've added a ```?``` at the end to signify it being optional.